### PR TITLE
Thrift does not need to set `python_source_root`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ An example repository to demonstrate codegen support in Pants.
 
 Refer to these docs for more information:
 
-* [Python Protobuf](https://www.pantsbuild.org/docs/protobuf-python
-* [Python Thrift](https://www.pantsbuild.org/docs/protobuf-python
+* [Python Protobuf](https://www.pantsbuild.org/docs/protobuf-python)
+* [Python Thrift](https://www.pantsbuild.org/docs/protobuf-python)
 
 Run `./pants export-codegen ::` to see the generated files. This isn't necessary for Pants to 
 use the generated files, but can be useful when debugging or to generate files for IDEs.

--- a/src/protobuf/simple_example/BUILD
+++ b/src/protobuf/simple_example/BUILD
@@ -1,3 +1,6 @@
 protobuf_sources(
+    # This will generate files under `src/python`, rather than `src/protobuf`, which is convenient
+    # so that we do not need to add `__init__.py` files to `src/protobuf`. See
+    # https://www.pantsbuild.org/docs/protobuf-python#protobuf-and-source-roots
     python_source_root="src/python",
 )

--- a/src/thrift/BUILD
+++ b/src/thrift/BUILD
@@ -1,3 +1,1 @@
-thrift_sources(
-    python_source_root="src/python",
-)
+thrift_sources()


### PR DESCRIPTION
That's because Thrift already generates all the `__init__.py` files we need for us for imports to work. Quite convenient! See the table at https://www.pantsbuild.org/v2.10/docs/thrift-python#step-4-confirm-python-imports-are-working for what Pants generates (found via `export-codegen` goal). There is no benefit to relocating.

I will be removing this field from pantsbuild/pants shortly.